### PR TITLE
Added flux queries compatibility

### DIFF
--- a/pkg/backend/retry.go
+++ b/pkg/backend/retry.go
@@ -82,7 +82,7 @@ func (r *retryBuffer) Post(buf []byte, query string, auth string, endpoint strin
 	return &ResponseData{StatusCode: http.StatusAccepted}, err
 }
 
-func (r *retryBuffer) Query(query string, auth string, endpoint string) (*http.Response, error) {
+func (r *retryBuffer) Query(method string, query string, auth string, endpoint string, body []byte) (*http.Response, error) {
 	return nil, nil
 }
 

--- a/test/README.md
+++ b/test/README.md
@@ -44,6 +44,7 @@ docker-compose up -d
 testing env has an enbedded grafana with a review dashboad doing queries from relay and also from both influx nodes
 
 http://localhost:3000/d/TEST_INFLUXDB_SRELAY_DASHBOARD/test_influxdb_srelay_dashboard
+http://localhost:3000/d/TEST_INFLUXDB_SRELAY_FLUX/test_influxdb_srelay_flux
 
 
 ![dashboard](./test_dashboard.png)
@@ -57,7 +58,7 @@ Restart to route metrics to a localy started relay
 ```
 cd test
 docker-compose up -d
-sed -i  's|http://relay:9096|http://<YOUR_IP>:9096|g' grafana/datasources/datasource.yam
+sed -i  's|http://relay:9096|http://<YOUR_IP>:9096|g' grafana/datasources/datasource.yaml
 docker-compose restart grafana
 ```
 Start relay with bra (it will execute `.bra.toml` commands and will restart relay on each change)

--- a/test/grafana/dashboards/TEST_INFLUXDB_SRELAY_FLUX.json
+++ b/test/grafana/dashboards/TEST_INFLUXDB_SRELAY_FLUX.json
@@ -1,0 +1,314 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 2,
+    "links": [],
+    "panels": [
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Flux-relay(testdb_linux)",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "interval": ">60s",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "hide": false,
+            "query": "from(bucket: \"testdb_linux/autogen\")\n  |> range($range)\n  |> filter(fn: (r) =>\n    r._measurement == \"cpu\" and\n    r._field == \"usage_system\" and\n    r.cpu == \"cpu-total\"\n  )\n",
+            "refId": "A",
+            "resultFormat": "time_series"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "FLUX-DB[testdb_linux]-QueryFrom-[RELAY]",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Flux-node-a(testdb_linux)",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 8,
+          "y": 0
+        },
+        "id": 4,
+        "interval": ">60s",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "hide": false,
+            "query": "from(bucket: \"testdb_linux/autogen\")\n  |> range($range)\n  |> filter(fn: (r) =>\n    r._measurement == \"cpu\" and\n    r._field == \"usage_system\" and\n    r.cpu == \"cpu-total\"\n  )\n",
+            "refId": "A",
+            "resultFormat": "time_series"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "FLUX-DB[testdb_linux]-QueryFrom-[NODE-A]",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Flux-node-b(testdb_linux)",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 16,
+          "y": 0
+        },
+        "id": 3,
+        "interval": ">60s",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "hide": false,
+            "query": "from(bucket: \"testdb_linux/autogen\")\n  |> range($range)\n  |> filter(fn: (r) =>\n    r._measurement == \"cpu\" and\n    r._field == \"usage_system\" and\n    r.cpu == \"cpu-total\"\n  )\n",
+            "refId": "A",
+            "resultFormat": "time_series"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "FLUX-DB[testdb_linux]-QueryFrom-[NODE-B]",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "schemaVersion": 20,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "",
+    "title": "TEST_INFLUXDB_SRELAY_FLUX",
+    "uid": "TEST_INFLUXDB_SRELAY_FLUX",
+    "version": 3
+  }

--- a/test/relay.devel.conf
+++ b/test/relay.devel.conf
@@ -23,7 +23,7 @@
 
   name  = "cluster_linux"
   members = ["influxdb01","influxdb02"]
-  log-file = "cluster_linux.log"
+  log-file = ""
   log-level = "debug"
   type = "HA"
   rate-limit = 100  
@@ -35,12 +35,38 @@
 [[http]]
   name = "example-http-influxdb2"
   bind-addr = "0.0.0.0:9096"
-  log-file = "http_relay_9096.log"
+  log-file = ""
   log-level = "debug"
-  access-log = "access.log"
+  access-log = ""
 
   rate-limit = 1000000
   burst-limit = 2000000
+
+
+  # Flux /api/v2/query Endpoint
+  #
+  [[http.endpoint]]
+    uri=["/api/v2/query"]
+    type="RD"
+    source_format="IQL"
+
+    [[http.endpoint.route]]
+      name="pass_thougth"
+      level="http" # http or data
+      log-inherit = true
+      log-level = "debug"
+
+      [[http.endpoint.route.filter]]
+        name="pass_all"
+        key="db" #availabe http params
+        match=".*"
+
+      [[http.endpoint.route.rule]]
+        name="pass_all"
+        action="route"
+        key="db"
+        match=".*"
+        to_cluster="cluster_linux"
 
   # IQL /query Endpoint
   #
@@ -60,7 +86,7 @@
     [[http.endpoint.route]]
       name="testdb_linux_metrics"
       level="http" # http or data
-      log-inherit = false
+      log-inherit = true
       log-level = "debug"
 
       [[http.endpoint.route.filter]]
@@ -78,6 +104,7 @@
     [[http.endpoint.route]]
       name="testdb_docker_metrics"
       level="http" # http or data
+      log-inherit = true
 
       [[http.endpoint.route.filter]]
         name="pass_testdb_docker_metrics"
@@ -95,6 +122,7 @@
     [[http.endpoint.route]]
       name="testdb_telegraf_metrics"
       level="http" # http or data
+      log-inherit = true
 
       [[http.endpoint.route.filter]]
         name="pass_testdb_telegraf_metrics"
@@ -118,7 +146,7 @@
     [[http.endpoint.route]]
       name="testdb_linux_metrics"
       level="http" # http or data
-      log-inherit = false
+      log-inherit = true
       log-level = "debug"
 
       [[http.endpoint.route.filter]]
@@ -136,6 +164,7 @@
     [[http.endpoint.route]]
       name="testdb_docker_metrics"
       level="http" # http or data
+      log-inherit = true
 
       [[http.endpoint.route.filter]]
         name="pass_testdb_docker_metrics"
@@ -153,6 +182,7 @@
     [[http.endpoint.route]]
       name="testdb_telegraf_metrics"
       level="http" # http or data
+      log-inherit = true
 
       [[http.endpoint.route.filter]]
         name="pass_testdb_telegraf_metrics"
@@ -170,6 +200,7 @@
     [[http.endpoint.route]]
       name="other_sinc"
       level="http"
+      log-inherit = true
 
       [[http.endpoint.route.filter]]
         name="pass_all"


### PR DESCRIPTION
now we can config a "pass-through" flux endpoint 

```toml
 [[http.endpoint]]
    uri=["/api/v2/query"]
    type="RD"
    source_format="IQL"

    [[http.endpoint.route]]
      name="pass_thougth"
      level="http" # http or data
      log-inherit = true
      log-level = "debug"

      [[http.endpoint.route.filter]]
        name="pass_all"
        key="db" #availabe http params
        match=".*"

      [[http.endpoint.route.rule]]
        name="pass_all"
        action="route"
        key="db"
        match=".*"
        to_cluster="cluster_linux"
```

