### PR TITLE
Add Info logging for admin queries

### DIFF
--- a/pkg/cluster/cluster-handlers.go
+++ b/pkg/cluster/cluster-handlers.go
@@ -209,10 +209,12 @@ func (c *Cluster) HandleAdmin(w http.ResponseWriter, r *http.Request) {
 	// No error !! The
 	if errResponse == nil {
 		adminresp.Msg = fmt.Sprintf("Cluster %s : Admin Action  %s: OK", c.cfg.Name, bodyBuf.String())
+                c.log.Info().Msgf("Cluster %s : Admin Action  %s: OK", c.cfg.Name, bodyBuf.String())
 		// Failed to make any valid request...
 		relayctx.JsonResponse(w, r, 200, adminresp)
 		return
 	}
 	adminresp.Msg = fmt.Sprintf("Cluster %s : Admin Action  %s: ERROR on ", c.cfg.Name, bodyBuf.String(), errResponse.Serverid)
+        c.log.Info().Msgf("Cluster %s : Admin Action  %s: ERROR on ", c.cfg.Name, bodyBuf.String(), errResponse.Serverid)
 	relayctx.JsonResponse(w, r, http.StatusBadRequest, adminresp)
 }


### PR DESCRIPTION
This is just a small change to provide logging for admin queries, so we can see if someone creates or drops a database without enabling debug logging.

Thanks,
Peter